### PR TITLE
chore: remove zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "react-i18next": "^15.1.0",
     "sonner": "^1.7.0",
     "tailwind-merge": "^2.5.4",
-    "valibot": "^1.0.0-beta.3",
-    "zod": "^3.23.8"
+    "valibot": "^1.0.0-beta.3"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       valibot:
         specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(typescript@5.6.3)
-      zod:
-        specifier: ^3.23.8
-        version: 3.23.8
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.2


### PR DESCRIPTION
Remove unused `zod` dependency. All linting and type-checking checks pass successfully after removal.